### PR TITLE
feature/circular-dropout

### DIFF
--- a/configs/trainer/dropout_scheduler/triangle.yaml
+++ b/configs/trainer/dropout_scheduler/triangle.yaml
@@ -1,4 +1,4 @@
 dropout_type: "triangle"
-start_dropout_p: 0.0
-end_dropout_p: 0.1
+dropout_trough: 0.0
+dropout_peak: 0.1
 cycle_factor: 4.0

--- a/configs/trainer/dropout_scheduler/triangle.yaml
+++ b/configs/trainer/dropout_scheduler/triangle.yaml
@@ -1,0 +1,4 @@
+dropout_type: "triangle"
+start_dropout_p: 0.0
+end_dropout_p: 0.1
+cycle_factor: 4.0

--- a/trainers/build_trainers.py
+++ b/trainers/build_trainers.py
@@ -79,8 +79,8 @@ def build_dropout_scheduler(trainer_cfg):
         )
     if trainer_cfg["dropout_scheduler"]["dropout_type"] == "triangle":
         return TriangleDropoutScheduler(
-            dropout_min=trainer_cfg["dropout_scheduler"]["start_dropout_p"],
-            dropout_max=trainer_cfg["dropout_scheduler"]["end_dropout_p"],
+            dropout_trough=trainer_cfg["dropout_scheduler"]["dropout_trough"],
+            dropout_peak=trainer_cfg["dropout_scheduler"]["dropout_peak"],
             max_iterations=trainer_cfg["training"]["max_iters"],
             gradient_accumulated_steps=trainer_cfg["training"]["gradient_accumulation_steps"],
             cycle_factor=trainer_cfg["dropout_scheduler"]["cycle_factor"],

--- a/trainers/build_trainers.py
+++ b/trainers/build_trainers.py
@@ -22,6 +22,7 @@ from trainers.scheduler import (
     DropoutScheduler,
     LinearDropoutScheduler,
     LRScheduler,
+    TriangleDropoutScheduler
 )
 
 OPTIMIZER_DICT = {
@@ -75,6 +76,14 @@ def build_dropout_scheduler(trainer_cfg):
             end_dropout_p=trainer_cfg["dropout_scheduler"]["end_dropout_p"],
             start_iter=trainer_cfg["dropout_scheduler"]["start_iter"],
             end_iter=trainer_cfg["dropout_scheduler"]["end_iter"],
+        )
+    if trainer_cfg["dropout_scheduler"]["dropout_type"] == "triangle":
+        return TriangleDropoutScheduler(
+            dropout_min=trainer_cfg["dropout_scheduler"]["start_dropout_p"],
+            dropout_max=trainer_cfg["dropout_scheduler"]["end_dropout_p"],
+            max_iterations=trainer_cfg["training"]["max_iters"],
+            gradient_accumulated_steps=trainer_cfg["training"]["gradient_accumulation_steps"],
+            cycle_factor=trainer_cfg["dropout_scheduler"]["cycle_factor"],
         )
     raise NotImplementedError(
         f"dropout scheduler {trainer_cfg['dropout_scheduler']['dropout_type']} not implemented."

--- a/trainers/scheduler.py
+++ b/trainers/scheduler.py
@@ -94,10 +94,10 @@ class LinearDropoutScheduler(DropoutScheduler):
 
 class TriangleDropoutScheduler(DropoutScheduler):
     '''Triangle Dropout Scheduler. Ref: https://arxiv.org/pdf/1506.01186'''
-    def __init__(self, dropout_min, dropout_max, max_iterations, gradient_accumulated_steps, cycle_factor = 4):
-        super().__init__(dropout_min)
-        self.dropout_min = dropout_min
-        self.dropout_max = dropout_max
+    def __init__(self, dropout_trough, dropout_peak, max_iterations, gradient_accumulated_steps, cycle_factor = 4):
+        super().__init__(dropout_trough)
+        self.dropout_trough = dropout_trough
+        self.dropout_peak = dropout_peak
         self.total_iterations = max_iterations * gradient_accumulated_steps
         self.cycle_length = self.total_iterations // cycle_factor
         self.num_cycles = cycle_factor 
@@ -106,9 +106,9 @@ class TriangleDropoutScheduler(DropoutScheduler):
         cycle_position = iter_num % self.cycle_length
         half_cycle = self.cycle_length / 2
         if cycle_position < half_cycle:
-            return self.dropout_min + (self.dropout_max - self.dropout_min) * (cycle_position / half_cycle)
+            return self.dropout_trough + (self.dropout_peak - self.dropout_trough) * (cycle_position / half_cycle)
         else:
-            return self.dropout_max - (self.dropout_max - self.dropout_min) * ((cycle_position - half_cycle) / half_cycle)
+            return self.dropout_peak - (self.dropout_peak - self.dropout_trough) * ((cycle_position - half_cycle) / half_cycle)
 
     def step(self, model, iter_num):
         dropout_p = self.get_dropout(iter_num)

--- a/trainers/scheduler.py
+++ b/trainers/scheduler.py
@@ -90,3 +90,27 @@ class LinearDropoutScheduler(DropoutScheduler):
         return self.start_dropout_p + (iter_num - self.start_iter) * (
             self.end_dropout_p - self.start_dropout_p
         ) / (self.end_iter - self.start_iter)
+
+
+class TriangleDropoutScheduler(DropoutScheduler):
+    '''Triangle Dropout Scheduler. Ref: https://arxiv.org/pdf/1506.01186'''
+    def __init__(self, dropout_min, dropout_max, max_iterations, gradient_accumulated_steps, cycle_factor = 4):
+        super().__init__(dropout_min)
+        self.dropout_min = dropout_min
+        self.dropout_max = dropout_max
+        self.total_iterations = max_iterations * gradient_accumulated_steps
+        self.cycle_length = self.total_iterations // cycle_factor
+        self.num_cycles = cycle_factor 
+
+    def get_dropout(self, iter_num):
+        cycle_position = iter_num % self.cycle_length
+        half_cycle = self.cycle_length / 2
+        if cycle_position < half_cycle:
+            return self.dropout_min + (self.dropout_max - self.dropout_min) * (cycle_position / half_cycle)
+        else:
+            return self.dropout_max - (self.dropout_max - self.dropout_min) * ((cycle_position - half_cycle) / half_cycle)
+
+    def step(self, model, iter_num):
+        dropout_p = self.get_dropout(iter_num)
+        self.set_dropout(model, dropout_p)
+        return dropout_p


### PR DESCRIPTION
I've added a triangle dropout rate scheduler, determined by parameters such as the minimum dropout, maximum dropout, and the number of cycles. This means the stepsize is 0.5 of 1 cycle length. This cycle length will be determined by the total number of iterations (gradient_accumulation_steps * max_iters) divided by the number of cycles. This means that the final iteration will be completed with the minimum dropout rate. 

Changes:
1. Created a triangle.yaml file that contains the parameters for this dropout scheduler.
2. Added the `TriangleDropoutScheduler` in the schedule.py file.
3. In the build_trainers.py file, I added the `TriangleDropoutScheduler` into the optimizer_dict. 