### PR TITLE
OOM issues with openwebtext

### DIFF
--- a/trainers/base_trainer.py
+++ b/trainers/base_trainer.py
@@ -130,7 +130,6 @@ class BaseTrainer:
             batch_size = self.batch_size,
             shuffle = False, ## previously True for SingleGPU
             num_workers = 0,
-            # sampler = DistributedSampler(self.dataloader) ## needed for DDP
         )
 
         ## cache the dataloader
@@ -215,9 +214,6 @@ class BaseTrainer:
         """Run a single step of training"""
         ## init Pytorch's DataLoader
         dataloader = self._prepare_dataloader("train")
-
-        ## set the epoch for the DistributedSampler (https://discuss.pytorch.org/t/why-is-sampler-set-epoch-epoch-needed-for-distributedsampler/149672/2)
-        # dataloader.sampler.set_epoch(epoch)
 
         for iter, (x, y) in enumerate(islice(dataloader, self.gradient_accumulation_steps)):
             with self.ctx:

--- a/trainers/base_trainer.py
+++ b/trainers/base_trainer.py
@@ -130,7 +130,7 @@ class BaseTrainer:
             batch_size = self.batch_size,
             shuffle = False, ## previously True for SingleGPU
             num_workers = 0,
-            sampler = DistributedSampler(self.dataloader) ## needed for DDP
+            # sampler = DistributedSampler(self.dataloader) ## needed for DDP
         )
 
         ## cache the dataloader
@@ -217,7 +217,7 @@ class BaseTrainer:
         dataloader = self._prepare_dataloader("train")
 
         ## set the epoch for the DistributedSampler (https://discuss.pytorch.org/t/why-is-sampler-set-epoch-epoch-needed-for-distributedsampler/149672/2)
-        dataloader.sampler.set_epoch(epoch)
+        # dataloader.sampler.set_epoch(epoch)
 
         for iter, (x, y) in enumerate(islice(dataloader, self.gradient_accumulation_steps)):
             with self.ctx:

--- a/trainers/dataloader.py
+++ b/trainers/dataloader.py
@@ -66,8 +66,8 @@ class BaseDataloader:
         
         Note: This works for BytePooling and StandardDataloader, but not for ConversationalDataloader and NextTokenMLMDataloader
         '''
-        idx = torch.randint(0, len(self.data) - self.context_window, (1,)).item()
-        
+        idx = torch.randint(0, len(self.data) - self.context_window, (1,)).item() ## implementing our own random sampling here to avoid issues with Pytorch's DataLoader
+
         X = torch.from_numpy((self.data[idx : idx + self.context_window]).astype(np.int64))
         y = torch.from_numpy((self.data[idx + 1 : idx + 1 + self.context_window]).astype(np.int64))
 

--- a/trainers/dataloader.py
+++ b/trainers/dataloader.py
@@ -66,6 +66,8 @@ class BaseDataloader:
         
         Note: This works for BytePooling and StandardDataloader, but not for ConversationalDataloader and NextTokenMLMDataloader
         '''
+        idx = torch.randint(0, len(self.data) - self.context_window, (1,)).item()
+        
         X = torch.from_numpy((self.data[idx : idx + self.context_window]).astype(np.int64))
         y = torch.from_numpy((self.data[idx + 1 : idx + 1 + self.context_window]).astype(np.int64))
 


### PR DESCRIPTION
1. Refrained from using DistributedSampler - took too long which means we no need .set_epoch. Hence, commented out the .set_epoch.
2. Used torch.randint to shuffle the selection of idx in dataset's __getitem__(self, idx).